### PR TITLE
Add avatar selection and side cannonballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Client/.DS_Store
+Client/avatars/*

--- a/Client/assets/js/main_out.js
+++ b/Client/assets/js/main_out.js
@@ -66,6 +66,8 @@
             rPressed = false,
             tPressed = false,
             pPressed = false,
+            leftPressed = false,
+            rightPressed = false,
             wPressed = false;
         wHandle.onkeydown = function(event) {
             switch (event.keyCode) {
@@ -130,6 +132,20 @@
                         pPressed = true;
                     }
                     break;
+                case 90: // Z - left cannon
+                    if (!leftPressed && (!isTyping)) {
+                        sendMouseMove();
+                        sendUint8(26);
+                        leftPressed = true;
+                    }
+                    break;
+                case 88: // X - right cannon
+                    if (!rightPressed && (!isTyping)) {
+                        sendMouseMove();
+                        sendUint8(27);
+                        rightPressed = true;
+                    }
+                    break;
                 case 27: // esc
                     showOverlays(true);
                     break;
@@ -161,11 +177,17 @@
                 case 80:
                     pPressed = false;
                     break;
+                case 90:
+                    leftPressed = false;
+                    break;
+                case 88:
+                    rightPressed = false;
+                    break;
             }
         };
         wHandle.onblur = function() {
             sendUint8(19);
-            wPressed = spacePressed = qPressed = ePressed = rPressed = tPressed = pPressed = false
+            wPressed = spacePressed = qPressed = ePressed = rPressed = tPressed = pPressed = leftPressed = rightPressed = false
         };
 
         wHandle.onresize = canvasResize;
@@ -1146,6 +1168,31 @@
                     knownNameDict.push(response[i]);
                 }
             }
+        }
+    });
+
+    var knownAvatars = [];
+    $.getJSON('/avatars', function(list) {
+        knownAvatars = list;
+        var select = $('#avatarSelect');
+        select.append($('<option>').attr('value', '').text('Avatar wählen'));
+        list.forEach(function(item) {
+            select.append($('<option>').attr('value', item).text(item));
+        });
+        var saved = wHandle.localStorage ? wHandle.localStorage.getItem('selectedAvatar') : null;
+        if (saved && list.indexOf(saved) !== -1) {
+            select.val(saved);
+            $('#avatarPreview').attr('src', 'avatars/' + saved).show();
+        }
+    });
+    $('#avatarSelect').on('change', function() {
+        var val = $(this).val();
+        if (val) {
+            $('#avatarPreview').attr('src', 'avatars/' + val).show();
+            if (wHandle.localStorage) wHandle.localStorage.setItem('selectedAvatar', val);
+        } else {
+            $('#avatarPreview').hide();
+            if (wHandle.localStorage) wHandle.localStorage.removeItem('selectedAvatar');
         }
     });
 

--- a/Client/index.html
+++ b/Client/index.html
@@ -82,6 +82,8 @@
                 <div class="form-group">
                     <input id="nick" class="form-control save" data-box-id="0" placeholder="Minion" value="[7X]Name"
                         maxlength="25" />
+                    <select id="avatarSelect" class="form-control" style="margin-top:5px;"></select>
+                    <img id="avatarPreview" src="" style="display:none;width:60px;height:60px;margin-top:5px;border-radius:30px;" />
                     <!-- <select id="gamemode" class="form-control" onchange="setserver($(this).val());" required>
                         <option selected disabled>Gamemode:</option>
                         <option value="127.0.0.1:8081">FFS</option>

--- a/Server/src/PacketHandler.js
+++ b/Server/src/PacketHandler.js
@@ -69,6 +69,8 @@ PacketHandler.prototype.handshake_onCompleted = function (protocol, key) {
         22: this.message_onKeyE.bind(this),
         23: this.message_onKeyR.bind(this),
         24: this.message_onKeyT.bind(this),
+        26: this.message_onKeyLeft.bind(this),
+        27: this.message_onKeyRight.bind(this),
         99: this.message_onChat.bind(this),
         254: this.message_onStat.bind(this),
     };
@@ -241,6 +243,16 @@ PacketHandler.prototype.message_onKeyT = function (message) {
             client.frozen = player.minionFrozen;
         }
     }
+};
+
+PacketHandler.prototype.message_onKeyLeft = function(message) {
+    if (message.length !== 1) return;
+    this.gameServer.fireSideCannon(this.socket.playerTracker, -1);
+};
+
+PacketHandler.prototype.message_onKeyRight = function(message) {
+    if (message.length !== 1) return;
+    this.gameServer.fireSideCannon(this.socket.playerTracker, 1);
 };
 
 PacketHandler.prototype.message_onChat = function (message) {


### PR DESCRIPTION
## Summary
- add avatar select and preview logic to login screen
- serve available avatars via new `/avatars` endpoint
- implement left and right cannon shots triggered by Z and X keys
- remove binary avatar examples and ignore avatar directory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849eed6e440832cb7b57bc49fa595fc