### PR TITLE
Fix variable typo in PacketHandler

### DIFF
--- a/Server/src/PacketHandler.js
+++ b/Server/src/PacketHandler.js
@@ -138,7 +138,7 @@ PacketHandler.prototype.message_onKeySpace = function (message) {
 
 PacketHandler.prototype.message_onKeyQ = function (message) {
     if (message.length !== 1) return;
-    var tick = this.gameServer.tickCoutner;
+    var tick = this.gameServer.tickCounter;
     var dt = tick - this.lastQTick;
     if (dt < this.gameServer.config.ejectCooldown) {
         return;


### PR DESCRIPTION
## Summary
- fix variable `tickCounter` name in `PacketHandler.message_onKeyQ`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849ee10a948832c9b5e59a1540d8499